### PR TITLE
docs: installation option via OpenUPM

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # PlayerPrefs Editor for Unity 3D
 
 [![Flattr this git repo](http://api.flattr.com/button/flattr-badge-large.png)](https://flattr.com/@dysman)
+[![openupm](https://img.shields.io/npm/v/com.bgtools.playerprefseditor?label=openupm&registry_uri=https://package.openupm.com)](https://openupm.com/packages/com.bgtools.playerprefseditor/)
 
 Tool extension for the Unity Editor that enables easy access to the player preferences over a simple UI. Allows to view, add, remove and modify entries on the development machine.
 
@@ -32,6 +33,9 @@ Additionally it's available on the [Unity Asset Store](http://u3d.as/1RLa).
 Place the PlayerPrefsEditor folder somewhere in your project. It's not relevant where it's located, the plugin will find all of its files by itself.
 
 ### Unity Package Manager (UPM)
+
+**Via Git URL**
+
 Through the Unity Plugin Manager it's possible to install the plugin direct from this git repository.
 The UPM need a specific structure what will be provided into the *upm* branch.
 
@@ -40,6 +44,14 @@ Use following direct URL for the configuration:
 git@github.com:Dysman/bgTools-playerPrefsEditor.git#upm
 ```
 See official Unity documentation for more informations: [UI](https://docs.unity3d.com/Manual/upm-ui-giturl.html) or [manifest.json](https://docs.unity3d.com/Manual/upm-git.html)
+
+**Via OpenUPM**
+
+The package is available on the [openupm registry](https://openupm.com). It's recommended to install it via [openupm-cli](https://github.com/openupm/openupm-cli).
+
+```
+openupm add com.bgtools.playerprefseditor
+```
 
 ## Usage
 


### PR DESCRIPTION
Added installation option via [OpenUPM](https://openupm.com/), an open-source UPM registry with automatic build pipelines, which monitors Git tags (GitHub releases) to publish UPM packages.