### PR TITLE
Adding name of deleted items in warning

### DIFF
--- a/Packages/PlayerPrefsEditor/Editor/PreferencesEditor/PreferencesEditorWindow.cs
+++ b/Packages/PlayerPrefsEditor/Editor/PreferencesEditor/PreferencesEditorWindow.cs
@@ -212,7 +212,7 @@ namespace BgTools.PlayerPrefsEditor
                 userDefList.ReleaseKeyboardFocus();
                 unityDefList.ReleaseKeyboardFocus();
 
-                if (EditorUtility.DisplayDialog("Warning!", "Are you sure you want to delete this entry from PlayerPrefs? ", "Yes", "No"))
+                if (EditorUtility.DisplayDialog("Warning!", "Are you sure you want to delete this entry from PlayerPrefs: " + l.serializedProperty.GetArrayElementAtIndex(l.index).FindPropertyRelative("m_key").stringValue + " ? ", "Yes", "No"))
                 {
                     entryAccessor.IgnoreNextChange();
 

--- a/Packages/PlayerPrefsEditor/Editor/PreferencesEditor/PreferencesEditorWindow.cs
+++ b/Packages/PlayerPrefsEditor/Editor/PreferencesEditor/PreferencesEditorWindow.cs
@@ -357,7 +357,7 @@ namespace BgTools.PlayerPrefsEditor
                 GUILayout.FlexibleSpace();
 
                 EditorGUIUtility.SetIconSize(new Vector2(14.0f, 14.0f));
-                GUIContent watcherContent = (entryAccessor.IsMonitoring()) ? new GUIContent(ImageManager.Watching, "Watch changes") : new GUIContent(ImageManager.NotWatching, "Not watching changes");
+                GUIContent watcherContent = (entryAccessor.IsMonitoring()) ? new GUIContent(ImageManager.Watching, "Watching changes") : new GUIContent(ImageManager.NotWatching, "Not watching changes");
                 if (GUILayout.Button(watcherContent, EditorStyles.toolbarButton))
                 {
                     monitoring = !monitoring;


### PR DESCRIPTION
Added the name of the element going to be deleted in the "Are you sure you want to delete ... ?" so the user has a clearer warning

Also did a little wording change so the tooltip when you're watching changes cannot be missunderstanded for a "click here to watch chages"