### PR TITLE
process.WaitForExit fix for macos users which caused a hang

### DIFF
--- a/Packages/PlayerPrefsEditor/Editor/PreferencesEditor/PreferenceStorageAccessor.cs
+++ b/Packages/PlayerPrefsEditor/Editor/PreferencesEditor/PreferenceStorageAccessor.cs
@@ -217,7 +217,7 @@ namespace BgTools.PlayerPrefsEditor
                 process.StartInfo.Arguments = cmdStr;
                 process.Start();
 
-                process.WaitForExit();
+                process.WaitForExit(200);
                 string plist = process.StandardOutput.ReadToEnd();
 
                 MatchCollection matches = Regex.Matches(plist, @"(?: "")(.*)(?:"" =>.*)");


### PR DESCRIPTION
c# processes are kinda wonky, sometimes my unity would hang at process.WaitForExit() even though the process has ended. I did some digging and from this stackoverflow page:

https://stackoverflow.com/questions/139593/processstartinfo-hanging-on-waitforexit-why

I found that just giving a timeout to WaitForExit() fixes the problem. I've given 200 milliseconds however I have tried 100 and it works in my case however for bigger prefs it might not work!