### PR TITLE
Detecting new Unity Defined PlayerPrefs (Update PreferencesEditorWindow.cs)

### DIFF
--- a/Packages/PlayerPrefsEditor/Editor/PreferencesEditor/PreferencesEditorWindow.cs
+++ b/Packages/PlayerPrefsEditor/Editor/PreferencesEditor/PreferencesEditorWindow.cs
@@ -597,7 +597,7 @@ namespace CCG.PlayerPrefsEditor
 
             // Seperate keys int unity defined and user defined
             Dictionary<bool, List<string>> groups = keys
-                .GroupBy( (key) => key.StartsWith("unity.") || key.StartsWith("UnityGraphicsQuality") )
+                .GroupBy( (key) => key.StartsWith("unity.") || key.StartsWith("unity_") || key.StartsWith("UnityGraphicsQuality") || key.StartsWith("AddressablesRuntimeDataPath"))
                 .ToDictionary( (g) => g.Key, (g) => g.ToList() );
 
             unityDef = (groups.ContainsKey(true)) ? groups[true].ToArray() : new string[0];
@@ -700,3 +700,4 @@ public class MySearchField : SearchField
     public new string OnToolbarGUI(string text, params GUILayoutOption[] options) => this.OnToolbarGUI(GUILayoutUtility.GetRect(29f, 200f, 18f, 18f, EditorStyles.toolbarSearchField, options), text);
     public new string OnToolbarGUI(Rect rect, string text) => this.OnGUI(rect, text, EditorStyles.toolbarSearchField, EditorStyles.toolbarButton, EditorStyles.toolbarButton);
 }
+


### PR DESCRIPTION
"AddressablesRuntimeDataPath" is a PlayerPref used by com.unity.addressables package. And Unity services use the unity_ prefix for their PlayerPrefs.

<img width="1188" height="1212" alt="CleanShot 2025-10-04 at 16 12 10@2x" src="https://github.com/user-attachments/assets/166f4201-3369-4c2e-8a68-21bd3b518a65" />
